### PR TITLE
implement dark mode and fix close on quit

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -39,6 +39,15 @@
             >
               <i class="ri-save-3-line" aria-hidden="true"></i>
             </button>
+            <button
+              type="button"
+              class="toolbar-button icon-button"
+              aria-label="Toggle theme"
+              data-action="toggle-theme"
+              data-tooltip="Toggle dark mode"
+            >
+              <i class="ri-sun-line" aria-hidden="true"></i>
+            </button>
           </div>
           <div class="toolbar-right">
             <div class="toolbar-dropdown" data-dropdown="examples">

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { indentWithTab } from '@codemirror/commands';
 import { Compartment, EditorState, StateEffect } from '@codemirror/state';
 import { keymap } from '@codemirror/view';
-import { getCurrentWindow } from '@tauri-apps/api/window';
+import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { basicSetup, EditorView } from 'codemirror';
 import mermaid from 'mermaid';
 import 'remixicon/fonts/remixicon.css';
@@ -23,6 +23,7 @@ import {
 } from './preview/zoom';
 import { setupToolbarActions } from './toolbar/actions';
 import { setupToolbarShortcuts } from './toolbar/shortcuts';
+import { setupTheme, type ThemeController } from './window/theme';
 import {
   loadEditorZoom,
   loadSettingsStore,
@@ -69,17 +70,21 @@ async function bootstrap(): Promise<void> {
   const zoomResetBtn = document.querySelector<HTMLButtonElement>('[data-action="zoom-reset"]');
   const zoomLevelDisplay = document.querySelector<HTMLSpanElement>('[data-zoom-level]');
   const helpButton = document.querySelector<HTMLButtonElement>('[data-action="help"]');
+  const themeButton = document.querySelector<HTMLButtonElement>('[data-action="toggle-theme"]');
 
   if (!host || !previewElement) {
     return;
   }
 
-  mermaid.initialize({
-    startOnLoad: false,
-    securityLevel: 'strict',
-  });
-
-  const appWindow = getCurrentWindow();
+  let appWindow;
+  try {
+    // @ts-ignore
+    if (window.__TAURI_INTERNALS__) {
+      appWindow = getCurrentWebviewWindow();
+    }
+  } catch (e) {
+    console.warn('Failed to get current webview window', e);
+  }
   const store = await loadSettingsStore();
 
   const zoomController = createZoomController(previewElement, (level) => {
@@ -93,7 +98,7 @@ async function bootstrap(): Promise<void> {
     setupWheelZoom(previewPane, zoomController);
   }
 
-  if (store) {
+  if (store && appWindow) {
     await setupWindowPersistence(store, appWindow, WINDOW_PERSIST_DELAY);
   }
 
@@ -128,6 +133,10 @@ async function bootstrap(): Promise<void> {
       status.error(details);
     },
   });
+
+  // Setup theme
+  const themeController = await setupTheme(store);
+  themeButton?.addEventListener('click', () => themeController.toggle());
   const handleDocChange = (doc: string) => {
     isDocumentDirty = doc !== lastCommittedDoc;
     updateFileStatus();
@@ -169,6 +178,11 @@ async function bootstrap(): Promise<void> {
   });
 
   commitDocument(editor.state.doc.toString());
+
+  // Re-render preview when theme changes
+  window.addEventListener('theme-changed', () => {
+    schedulePreviewRender(editor.state.doc.toString());
+  });
 
   editor.focus();
   host.dataset.editor = 'mounted';

--- a/src/styles.css
+++ b/src/styles.css
@@ -5,6 +5,7 @@
   line-height: 1.6;
   margin: 0;
   --app-background: #f5f7fb;
+  --app-gradient: linear-gradient(0deg, #f5f7fb 0%, #e8ecf5 100%);
   --header-background: var(--app-background);
   --header-border: rgba(15, 23, 42, 0.08);
   --editor-bg: rgba(255, 255, 255, 0.95);
@@ -28,6 +29,7 @@ body {
 
 body.dark {
   --app-background: #121620;
+  --app-gradient: linear-gradient(0deg, #121620 0%, #1a1f2e 100%);
   --header-background: rgba(17, 24, 39, 0.85);
   --header-border: rgba(148, 163, 184, 0.2);
   color: #f8fafc;
@@ -43,7 +45,7 @@ body.dark {
   flex: 1 1 auto;
   min-height: 0;
   height: 100vh;
-  background: linear-gradient(0deg, #f5f7fb 0%, #e8ecf5 100%);
+  background: var(--app-gradient, linear-gradient(0deg, #f5f7fb 0%, #e8ecf5 100%));
 }
 
 .app-header {

--- a/src/toolbar/export-diagram.ts
+++ b/src/toolbar/export-diagram.ts
@@ -173,7 +173,8 @@ async function convertSvgToPng(diagram: RenderedDiagram, scale: number): Promise
 
   context.save();
   context.globalAlpha = 1;
-  context.fillStyle = '#ffffff';
+  const isDark = document.documentElement.dataset.theme === 'dark';
+  context.fillStyle = isDark ? '#1b2537' : '#ffffff';
   context.fillRect(0, 0, exportWidth, exportHeight);
   context.restore();
 

--- a/src/window/state.ts
+++ b/src/window/state.ts
@@ -1,5 +1,5 @@
-import { getCurrentWindow } from '@tauri-apps/api/window';
-import { Store } from '@tauri-apps/plugin-store';
+import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
+import { load } from '@tauri-apps/plugin-store';
 
 import { debounce } from '../utils/debounce';
 
@@ -15,13 +15,19 @@ export interface WindowStatePayload {
   maximized: boolean;
 }
 
-export type AppWindow = ReturnType<typeof getCurrentWindow>;
+export type Store = Awaited<ReturnType<typeof load>>;
+export type AppWindow = ReturnType<typeof getCurrentWebviewWindow>;
 
 export async function loadSettingsStore(): Promise<Store | null> {
+  // @ts-ignore
+  if (typeof window !== 'undefined' && !window.__TAURI_INTERNALS__) {
+    return null;
+  }
+
   try {
-    return await Store.load(SETTINGS_STORE_NAME);
+    return await load(SETTINGS_STORE_NAME);
   } catch (error) {
-    console.error('Failed to load settings store', error);
+    console.warn('Failed to load settings store', error);
     return null;
   }
 }
@@ -36,11 +42,13 @@ export async function setupWindowPersistence(
   const unlistenResize = await appWindow.onResized(() => debouncedPersist());
   const unlistenMove = await appWindow.onMoved(() => debouncedPersist());
 
-  await appWindow.onCloseRequested(async (event) => {
+  let unlistenClose: () => void;
+  unlistenClose = await appWindow.onCloseRequested(async (event) => {
     event.preventDefault();
     await persistWindowState(store, appWindow);
     if (typeof unlistenResize === 'function') unlistenResize();
     if (typeof unlistenMove === 'function') unlistenMove();
+    if (typeof unlistenClose === 'function') unlistenClose();
     await appWindow.close();
   });
 }

--- a/src/window/theme.ts
+++ b/src/window/theme.ts
@@ -1,0 +1,71 @@
+import { Store } from '@tauri-apps/plugin-store';
+import mermaid from 'mermaid';
+
+const THEME_KEY = 'appTheme';
+
+export type AppTheme = 'light' | 'dark';
+
+export interface ThemeController {
+  theme: AppTheme;
+  toggle(): void;
+  apply(): void;
+}
+
+export async function setupTheme(store: Store | null): Promise<ThemeController> {
+  let currentTheme: AppTheme = 'light';
+  if (store) {
+    const saved = await store.get<AppTheme>(THEME_KEY);
+    if (saved) {
+      currentTheme = saved;
+    }
+  }
+  document.documentElement.dataset.theme = currentTheme;
+
+  const applyTheme = () => {
+    document.body.classList.toggle('dark', currentTheme === 'dark');
+    document.documentElement.dataset.theme = currentTheme;
+    
+    // Update toggle button icon and tooltip
+    const toggleBtn = document.querySelector<HTMLButtonElement>('[data-action="toggle-theme"]');
+    if (toggleBtn) {
+      const icon = toggleBtn.querySelector('i');
+      if (icon) {
+        icon.className = currentTheme === 'dark' ? 'ri-sun-line' : 'ri-moon-line';
+      }
+      toggleBtn.setAttribute('data-tooltip', currentTheme === 'dark' ? 'Light mode' : 'Dark mode');
+      toggleBtn.setAttribute('aria-label', currentTheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode');
+    }
+
+    // Update Mermaid default configuration
+    mermaid.initialize({
+      startOnLoad: false,
+      securityLevel: 'strict',
+      theme: currentTheme === 'dark' ? 'dark' : 'default',
+    });
+    
+    // Trigger a custom event so other components (like the preview) know to re-render
+    window.dispatchEvent(new CustomEvent('theme-changed', { detail: { theme: currentTheme } }));
+  };
+
+  const controller: ThemeController = {
+    get theme() {
+      return currentTheme;
+    },
+    async toggle() {
+      currentTheme = currentTheme === 'light' ? 'dark' : 'light';
+      if (store) {
+        await store.set(THEME_KEY, currentTheme);
+        await store.save();
+      }
+      applyTheme();
+    },
+    apply() {
+      applyTheme();
+    },
+  };
+
+  // Initial apply
+  applyTheme();
+
+  return controller;
+}


### PR DESCRIPTION
Agent's Key Changes:
 - Dark Mode: Added a toolbar toggle for switching between light and dark themes. Preferences are
 persisted via the settings store.
 - Mermaid Integration: The diagram preview now dynamically switches between 'default' and 'dark'
 themes to match the application UI.
 - Export Updates: PNG exports now respect the current theme's background color.
 - Window Management: Fixed onCloseRequested handling to ensure window state (size/position) is
 saved correctly before exit.
 - Refactoring: Updated to use getCurrentWebviewWindow and improved error handling for the settings
 store initialization.